### PR TITLE
Pass runtime event actions lazily

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -37,7 +37,7 @@ def make_runtime_chat_delivery_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_actions(actions: list[RuntimeChatDeliveryAction]) -> int:
+    async def dispatch_actions(actions: Iterable[RuntimeChatDeliveryAction]) -> int:
         return await dispatch_runtime_chat_delivery_actions(
             app,
             actions,

--- a/backend/threads/chat_adapters/runtime_event_action_route.py
+++ b/backend/threads/chat_adapters/runtime_event_action_route.py
@@ -9,11 +9,10 @@ from typing import Any
 @dataclass(frozen=True)
 class RuntimeEventActionRoute[EventT, ActionT, ResultT]:
     planner: Callable[[EventT], Iterable[ActionT]]
-    dispatch_actions: Callable[[list[ActionT]], Coroutine[Any, Any, ResultT]]
+    dispatch_actions: Callable[[Iterable[ActionT]], Coroutine[Any, Any, ResultT]]
 
     async def dispatch(self, event: EventT) -> ResultT:
-        actions = list(self.planner(event))
-        return await self.dispatch_actions(actions)
+        return await self.dispatch_actions(self.planner(event))
 
     def sync_hook(self) -> Callable[[EventT], None]:
         loop = asyncio.get_running_loop()

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -38,7 +38,7 @@ def make_runtime_notification_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_actions(actions: list[RuntimeNotificationAction]) -> int:
+    async def dispatch_actions(actions: Iterable[RuntimeNotificationAction]) -> int:
         return await dispatch_runtime_notification_actions(
             app,
             actions,

--- a/tests/Unit/backend/web/services/test_runtime_event_action_route.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_action_route.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 
 import pytest
 
@@ -14,8 +15,8 @@ async def test_runtime_event_action_route_dispatches_planned_actions() -> None:
     def planner(value: str) -> list[str]:
         return [f"planned:{value}"]
 
-    async def dispatch_actions(actions: list[str]) -> str:
-        calls.append(actions)
+    async def dispatch_actions(actions: Iterable[str]) -> str:
+        calls.append(list(actions))
         return "sent"
 
     route = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions)
@@ -27,14 +28,38 @@ async def test_runtime_event_action_route_dispatches_planned_actions() -> None:
 
 
 @pytest.mark.asyncio
+async def test_runtime_event_action_route_does_not_materialize_planned_actions_before_dispatch() -> None:
+    events: list[str] = []
+
+    def planner(value: str) -> Iterable[str]:
+        events.append("planner-start")
+        yield f"planned:{value}"
+        events.append("planner-after-first")
+        yield "planned:late"
+
+    async def dispatch_actions(actions: Iterable[str]) -> str:
+        events.append("dispatch-start")
+        iterator = iter(actions)
+        events.append(next(iterator))
+        return "sent"
+
+    route = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions)
+
+    result = await route.dispatch("event-1")
+
+    assert result == "sent"
+    assert events == ["dispatch-start", "planner-start", "planned:event-1"]
+
+
+@pytest.mark.asyncio
 async def test_runtime_event_action_route_sync_hook_runs_from_worker_thread() -> None:
     calls: list[list[str]] = []
 
     def planner(value: str) -> list[str]:
         return [f"planned:{value}"]
 
-    async def dispatch_actions(actions: list[str]) -> None:
-        calls.append(actions)
+    async def dispatch_actions(actions: Iterable[str]) -> None:
+        calls.append(list(actions))
 
     hook = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions).sync_hook()
 
@@ -48,7 +73,7 @@ async def test_runtime_event_action_route_sync_hook_fails_loudly_on_owner_loop_t
     def planner(value: str) -> list[str]:
         return [value]
 
-    async def dispatch_actions(_actions: list[str]) -> None:
+    async def dispatch_actions(_actions: Iterable[str]) -> None:
         return None
 
     hook = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions).sync_hook()


### PR DESCRIPTION
## Summary

- Pass runtime event planner output directly into the action dispatcher.
- Type `RuntimeEventActionRoute.dispatch_actions` as an `Iterable` consumer.
- Keep chat delivery and notification hook adapters aligned with the lazy action boundary.

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py::test_runtime_event_action_route_does_not_materialize_planned_actions_before_dispatch -q` failed before implementation because route eagerly consumed `planner(event)` with `list(...)`.
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py -q` -> `4 passed`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q` -> `37 passed`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_action_route.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py` -> `All checks passed`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_action_route.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py` -> `4 files already formatted`
- `uv run pyright backend/threads/chat_adapters/runtime_event_action_route.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py` -> `0 errors, 0 warnings, 0 informations`
- `uv run pytest tests/Unit -q` -> `2243 passed, 3 skipped, 15 warnings`
