### PR TITLE
Split sync event hook bridge from runtime route

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -8,6 +8,7 @@ from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_event_action_route import RuntimeEventActionRoute
 from backend.threads.chat_adapters.runtime_identity import runtime_actor
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_chat_delivery_recipient
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_sync_runtime_event_hook
 from protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -45,10 +46,11 @@ def make_runtime_chat_delivery_event_hook[EventT](
             activity_reader=activity_reader,
         )
 
-    return RuntimeEventActionRoute(
+    route = RuntimeEventActionRoute(
         planner=planner,
         dispatch_actions=dispatch_actions,
-    ).sync_hook()
+    )
+    return make_sync_runtime_event_hook(route.dispatch)
 
 
 async def dispatch_runtime_chat_delivery_actions(

--- a/backend/threads/chat_adapters/runtime_event_action_route.py
+++ b/backend/threads/chat_adapters/runtime_event_action_route.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from typing import Any
@@ -13,21 +12,3 @@ class RuntimeEventActionRoute[EventT, ActionT, ResultT]:
 
     async def dispatch(self, event: EventT) -> ResultT:
         return await self.dispatch_actions(self.planner(event))
-
-    def sync_hook(self) -> Callable[[EventT], None]:
-        loop = asyncio.get_running_loop()
-
-        async def dispatch_event(event: EventT) -> None:
-            await self.dispatch(event)
-
-        def hook(event: EventT) -> None:
-            try:
-                current_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                current_loop = None
-            if current_loop is loop:
-                raise RuntimeError("Sync runtime event hook cannot run on its owner event loop thread")
-            future = asyncio.run_coroutine_threadsafe(dispatch_event(event), loop)
-            future.result()
-
-        return hook

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -8,6 +8,7 @@ from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_event_action_route import RuntimeEventActionRoute
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_sync_runtime_event_hook
 from protocols.agent_runtime import (
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
@@ -47,10 +48,11 @@ def make_runtime_notification_event_hook[EventT](
             activity_reader=activity_reader,
         )
 
-    return RuntimeEventActionRoute(
+    route = RuntimeEventActionRoute(
         planner=planner,
         dispatch_actions=dispatch_actions,
-    ).sync_hook()
+    )
+    return make_sync_runtime_event_hook(route.dispatch)
 
 
 async def dispatch_runtime_notification_actions(

--- a/backend/threads/chat_adapters/runtime_sync_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_sync_event_hook.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+
+def make_sync_runtime_event_hook[EventT](
+    dispatch_event: Callable[[EventT], Coroutine[Any, Any, Any]],
+) -> Callable[[EventT], None]:
+    loop = asyncio.get_running_loop()
+
+    def hook(event: EventT) -> None:
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if current_loop is loop:
+            raise RuntimeError("Sync runtime event hook cannot run on its owner event loop thread")
+        future = asyncio.run_coroutine_threadsafe(dispatch_event(event), loop)
+        future.result()
+
+    return hook

--- a/tests/Unit/backend/web/services/test_runtime_event_action_route.py
+++ b/tests/Unit/backend/web/services/test_runtime_event_action_route.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 import pytest
 
 from backend.threads.chat_adapters.runtime_event_action_route import RuntimeEventActionRoute
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_sync_runtime_event_hook
 
 
 @pytest.mark.asyncio
@@ -51,8 +52,12 @@ async def test_runtime_event_action_route_does_not_materialize_planned_actions_b
     assert events == ["dispatch-start", "planner-start", "planned:event-1"]
 
 
+def test_runtime_event_action_route_does_not_own_sync_hook_bridge() -> None:
+    assert not hasattr(RuntimeEventActionRoute, "sync_hook")
+
+
 @pytest.mark.asyncio
-async def test_runtime_event_action_route_sync_hook_runs_from_worker_thread() -> None:
+async def test_sync_runtime_event_hook_runs_from_worker_thread() -> None:
     calls: list[list[str]] = []
 
     def planner(value: str) -> list[str]:
@@ -61,7 +66,8 @@ async def test_runtime_event_action_route_sync_hook_runs_from_worker_thread() ->
     async def dispatch_actions(actions: Iterable[str]) -> None:
         calls.append(list(actions))
 
-    hook = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions).sync_hook()
+    route = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions)
+    hook = make_sync_runtime_event_hook(route.dispatch)
 
     await asyncio.to_thread(hook, "event-1")
 
@@ -69,14 +75,15 @@ async def test_runtime_event_action_route_sync_hook_runs_from_worker_thread() ->
 
 
 @pytest.mark.asyncio
-async def test_runtime_event_action_route_sync_hook_fails_loudly_on_owner_loop_thread() -> None:
+async def test_sync_runtime_event_hook_fails_loudly_on_owner_loop_thread() -> None:
     def planner(value: str) -> list[str]:
         return [value]
 
     async def dispatch_actions(_actions: Iterable[str]) -> None:
         return None
 
-    hook = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions).sync_hook()
+    route = RuntimeEventActionRoute(planner=planner, dispatch_actions=dispatch_actions)
+    hook = make_sync_runtime_event_hook(route.dispatch)
 
     with pytest.raises(RuntimeError) as exc:
         hook("event-1")


### PR DESCRIPTION
## Summary

- Remove sync hook bridging from `RuntimeEventActionRoute` so the route stays a pure async event/action primitive.
- Add `runtime_sync_event_hook.make_sync_runtime_event_hook()` as the small adapter-boundary bridge from async dispatch to synchronous hooks.
- Keep chat delivery and notification hook factories behaviorally unchanged by composing the route dispatch with the sync bridge.

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py -q` failed before implementation because `runtime_sync_event_hook` did not exist.
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py -q` -> `5 passed`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_event_action_route.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py -q` -> `38 passed`
- `uv run ruff check backend/threads/chat_adapters/runtime_event_action_route.py backend/threads/chat_adapters/runtime_sync_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py` -> `All checks passed`
- `uv run ruff format --check backend/threads/chat_adapters/runtime_event_action_route.py backend/threads/chat_adapters/runtime_sync_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py` -> `5 files already formatted`
- `uv run pyright backend/threads/chat_adapters/runtime_event_action_route.py backend/threads/chat_adapters/runtime_sync_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py` -> `0 errors, 0 warnings, 0 informations`
- `uv run pytest tests/Unit -q` -> `2244 passed, 3 skipped, 15 warnings`
