### PR TITLE
Plan workflow event actions lazily

### DIFF
--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from backend.threads.chat_adapters.runtime_notification_action import (
@@ -29,8 +29,10 @@ def make_workflow_event_notification_fn(
     )
 
 
-def workflow_event_notification_action_planner(messaging_service: Any) -> Callable[[WorkflowEventChange], list[RuntimeNotificationAction]]:
-    def plan(change: WorkflowEventChange) -> list[RuntimeNotificationAction]:
+def workflow_event_notification_action_planner(
+    messaging_service: Any,
+) -> Callable[[WorkflowEventChange], Iterable[RuntimeNotificationAction]]:
+    def plan(change: WorkflowEventChange) -> Iterable[RuntimeNotificationAction]:
         return make_workflow_event_notification_actions(
             change,
             messaging_service.list_chat_members(_required_str(change.event, "chat_id")),
@@ -41,15 +43,13 @@ def workflow_event_notification_action_planner(messaging_service: Any) -> Callab
 
 def make_workflow_event_notification_actions(
     change: WorkflowEventChange,
-    members: Sequence[Mapping[str, Any]],
-) -> list[RuntimeNotificationAction]:
-    actions: list[RuntimeNotificationAction] = []
+    members: Iterable[Mapping[str, Any]],
+) -> Iterable[RuntimeNotificationAction]:
     for member in members:
         recipient_user_id = _member_user_id(member)
         if recipient_user_id == change.actor_user_id:
             continue
-        actions.append(workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id))
-    return actions
+        yield workflow_event_runtime_notification_action(change=change, recipient_user_id=recipient_user_id)
 
 
 def workflow_event_runtime_notification_action(*, change: WorkflowEventChange, recipient_user_id: str) -> RuntimeNotificationAction:

--- a/tests/Unit/backend/web/services/test_workflow_event_notification.py
+++ b/tests/Unit/backend/web/services/test_workflow_event_notification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Literal
 
@@ -140,9 +141,11 @@ def test_workflow_event_notification_fails_loudly_on_missing_identity() -> None:
 
 
 def test_workflow_event_notification_planner_selects_recipient_actions() -> None:
-    actions = make_workflow_event_notification_actions(
-        _change("updated"),
-        _members("owner-1", "agent-1", "agent-without-thread", "external-1", "human-2"),
+    actions = list(
+        make_workflow_event_notification_actions(
+            _change("updated"),
+            _members("owner-1", "agent-1", "agent-without-thread", "external-1", "human-2"),
+        )
     )
 
     assert [action.recipient_user_id for action in actions] == ["agent-1", "agent-without-thread", "external-1", "human-2"]
@@ -151,6 +154,26 @@ def test_workflow_event_notification_planner_selects_recipient_actions() -> None
         assert action.metadata is not None
         assert action.metadata["event_id"] == "event-1"
         assert action.metadata["operation"] == "updated"
+
+
+def test_workflow_event_notification_actions_are_planned_lazily() -> None:
+    events: list[str] = []
+
+    def members() -> Iterator[dict[str, str]]:
+        events.append("members-start")
+        yield {"user_id": "owner-1"}
+        events.append("after-owner")
+        yield {"user_id": "agent-1"}
+        events.append("after-agent")
+        yield {"user_id": "agent-2"}
+
+    actions = make_workflow_event_notification_actions(_change("updated"), members())
+    events.append("before-first-action")
+
+    first = next(iter(actions))
+
+    assert first.recipient_user_id == "agent-1"
+    assert events == ["before-first-action", "members-start", "after-owner"]
 
 
 def test_workflow_event_notification_action_planner_reads_chat_members() -> None:
@@ -162,7 +185,7 @@ def test_workflow_event_notification_action_planner_reads_chat_members() -> None
 
     planner = workflow_event_notification_action_planner(SimpleNamespace(list_chat_members=list_chat_members))
 
-    actions = planner(_change("updated"))
+    actions = list(planner(_change("updated")))
 
     assert seen_chat_ids == ["chat-1"]
     assert [action.recipient_user_id for action in actions] == ["agent-1"]


### PR DESCRIPTION
## Summary

- Make workflow event notification action planning lazy for the real one-to-many fanout path.
- Keep workflow notification behavior unchanged while returning an iterable action plan.
- Add a regression test proving member rows are not consumed until the caller requests the first action.

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py::test_workflow_event_notification_actions_are_planned_lazily -q` failed before implementation because members were consumed before the first action request.
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py -q` -> `8 passed`
- `uv run pytest tests/Unit/backend/web/services/test_workflow_event_notification.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_event_action_route.py -q` -> `16 passed`
- `uv run ruff check backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py` -> `All checks passed`
- `uv run ruff format backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py` -> `2 files left unchanged`
- `uv run pyright backend/threads/chat_adapters/workflow_event_inlet.py tests/Unit/backend/web/services/test_workflow_event_notification.py` -> `0 errors, 0 warnings, 0 informations`
- `uv run pytest tests/Unit -q` -> `2245 passed, 3 skipped, 15 warnings`
