### PR TITLE
Clarify blocking runtime event hook

### DIFF
--- a/backend/threads/chat_adapters/runtime_chat_delivery_action.py
+++ b/backend/threads/chat_adapters/runtime_chat_delivery_action.py
@@ -7,7 +7,7 @@ from typing import Any
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_identity import runtime_actor
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_chat_delivery_recipient
-from backend.threads.chat_adapters.runtime_sync_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_blocking_runtime_event_hook
 from protocols.agent_runtime import (
     AgentChatContext,
     AgentChatDeliveryEnvelope,
@@ -37,18 +37,15 @@ def make_runtime_chat_delivery_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_actions(actions: Iterable[RuntimeChatDeliveryAction]) -> int:
+    async def dispatch_event(event: EventT) -> int:
         return await dispatch_runtime_chat_delivery_actions(
             app,
-            actions,
+            planner(event),
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
-    async def dispatch_event(event: EventT) -> int:
-        return await dispatch_actions(planner(event))
-
-    return make_sync_runtime_event_hook(dispatch_event)
+    return make_blocking_runtime_event_hook(dispatch_event)
 
 
 async def dispatch_runtime_chat_delivery_actions(

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -7,7 +7,7 @@ from typing import Any
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
-from backend.threads.chat_adapters.runtime_sync_event_hook import make_sync_runtime_event_hook
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_blocking_runtime_event_hook
 from protocols.agent_runtime import (
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
@@ -38,19 +38,16 @@ def make_runtime_notification_event_hook[EventT](
     thread_repo: Any,
     activity_reader: Any,
 ) -> Callable[[EventT], None]:
-    async def dispatch_actions(actions: Iterable[RuntimeNotificationAction]) -> int:
+    async def dispatch_event(event: EventT) -> int:
         return await dispatch_runtime_notification_actions(
             app,
-            actions,
+            planner(event),
             user_repo=user_repo,
             thread_repo=thread_repo,
             activity_reader=activity_reader,
         )
 
-    async def dispatch_event(event: EventT) -> int:
-        return await dispatch_actions(planner(event))
-
-    return make_sync_runtime_event_hook(dispatch_event)
+    return make_blocking_runtime_event_hook(dispatch_event)
 
 
 async def dispatch_runtime_notification_actions(

--- a/backend/threads/chat_adapters/runtime_sync_event_hook.py
+++ b/backend/threads/chat_adapters/runtime_sync_event_hook.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 
-def make_sync_runtime_event_hook[EventT](
+def make_blocking_runtime_event_hook[EventT](
     dispatch_event: Callable[[EventT], Coroutine[Any, Any, Any]],
 ) -> Callable[[EventT], None]:
     loop = asyncio.get_running_loop()
@@ -16,7 +16,7 @@ def make_sync_runtime_event_hook[EventT](
         except RuntimeError:
             current_loop = None
         if current_loop is loop:
-            raise RuntimeError("Sync runtime event hook cannot run on its owner event loop thread")
+            raise RuntimeError("Blocking runtime event hook cannot run on its owner event loop thread")
         future = asyncio.run_coroutine_threadsafe(dispatch_event(event), loop)
         future.result()
 

--- a/tests/Unit/backend/web/services/test_runtime_sync_event_hook.py
+++ b/tests/Unit/backend/web/services/test_runtime_sync_event_hook.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Coroutine, Iterator
+from typing import Any
+
+import pytest
+
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_blocking_runtime_event_hook
+
+
+class LoopThread:
+    def __init__(self) -> None:
+        self.loop_ready: threading.Event = threading.Event()
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+        assert self.loop_ready.wait(1)
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self.loop = loop
+        self.loop_ready.set()
+        loop.run_forever()
+        loop.close()
+
+    def run(self, coroutine: Coroutine[Any, Any, Any]) -> Any:
+        loop = self.loop
+        assert loop is not None
+        return asyncio.run_coroutine_threadsafe(coroutine, loop).result(timeout=1)
+
+    def close(self) -> None:
+        loop = self.loop
+        assert loop is not None
+        loop.call_soon_threadsafe(loop.stop)
+        self.thread.join(timeout=1)
+
+
+@pytest.fixture
+def loop_thread() -> Iterator[LoopThread]:
+    thread = LoopThread()
+    try:
+        yield thread
+    finally:
+        thread.close()
+
+
+def test_blocking_runtime_event_hook_blocks_producer_until_dispatch_completes(loop_thread: LoopThread) -> None:
+    dispatch_started = threading.Event()
+    release_dispatch = threading.Event()
+    producer_done = threading.Event()
+    producer_error: list[BaseException] = []
+
+    async def make_hook():
+        async def dispatch_event(value: str) -> int:
+            dispatch_started.set()
+            await asyncio.to_thread(release_dispatch.wait)
+            return len(value)
+
+        return make_blocking_runtime_event_hook(dispatch_event)
+
+    hook = loop_thread.run(make_hook())
+
+    def run_producer() -> None:
+        try:
+            assert hook("event-1") is None
+        except BaseException as exc:
+            producer_error.append(exc)
+        finally:
+            producer_done.set()
+
+    producer = threading.Thread(target=run_producer)
+    producer.start()
+
+    assert dispatch_started.wait(1)
+    assert not producer_done.wait(0.05)
+
+    release_dispatch.set()
+    producer.join(timeout=1)
+
+    assert producer_done.is_set()
+    assert producer_error == []
+
+
+def test_blocking_runtime_event_hook_raises_dispatch_failure_in_producer(loop_thread: LoopThread) -> None:
+    async def make_hook():
+        async def dispatch_event(_value: str) -> None:
+            raise RuntimeError("runtime offline")
+
+        return make_blocking_runtime_event_hook(dispatch_event)
+
+    hook = loop_thread.run(make_hook())
+
+    with pytest.raises(RuntimeError) as exc_info:
+        hook("event-1")
+
+    assert str(exc_info.value) == "runtime offline"
+
+
+def test_blocking_runtime_event_hook_refuses_owner_loop_thread(loop_thread: LoopThread) -> None:
+    async def make_and_call_hook() -> None:
+        async def dispatch_event(_value: str) -> None:
+            raise AssertionError("dispatch should not run on owner loop")
+
+        hook = make_blocking_runtime_event_hook(dispatch_event)
+        hook("event-1")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        loop_thread.run(make_and_call_hook())
+
+    assert str(exc_info.value) == "Blocking runtime event hook cannot run on its owner event loop thread"


### PR DESCRIPTION
## Summary

- rename the sync runtime hook bridge to `make_blocking_runtime_event_hook`
- add tests for the producer-blocking bridge contract
- inline two dead `dispatch_actions` closures in chat delivery and notification hook factories

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_sync_event_hook.py -q`
- `uv run pytest tests/Unit/backend/web/services/test_runtime_sync_event_hook.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/backend/web/services/test_chat_delivery_hook.py tests/Unit/backend/web/services/test_workflow_event_notification.py -q`
- `uv run pytest tests/Unit -q`
- `uv run ruff check backend/threads/chat_adapters tests/Unit/backend/web/services/test_runtime_sync_event_hook.py`
- `uv run ruff format --check backend/threads/chat_adapters tests/Unit/backend/web/services/test_runtime_sync_event_hook.py`
- `uv run pyright backend/threads/chat_adapters/runtime_sync_event_hook.py backend/threads/chat_adapters/runtime_chat_delivery_action.py backend/threads/chat_adapters/runtime_notification_action.py tests/Unit/backend/web/services/test_runtime_sync_event_hook.py`

Note: full `uv run pyright` is not a usable local gate on current dev; it reports existing errors outside this slice.
