### PR TITLE
Guard provider webhooks from event actions

### DIFF
--- a/backend/web/routers/webhooks.py
+++ b/backend/web/routers/webhooks.py
@@ -1,3 +1,10 @@
+"""Sandbox provider observation only.
+
+This router records provider webhook payloads and observes matched sandbox
+runtime state. It is not the Mycel event/action entrypoint for chat, user,
+notification, or runtime-inbox automation.
+"""
+
 import asyncio
 from typing import Any
 
@@ -7,6 +14,9 @@ from backend.sandboxes.inventory import init_providers_and_managers
 from sandbox.runtime_handle import sandbox_runtime_from_row
 from storage.container_cache import get_storage_container as _get_container
 from storage.runtime import build_sandbox_runtime_repo as make_sandbox_runtime_repo
+
+# @@@webhook-not-mycel-event-entrypoint - Keep provider webhooks out of chat/user event-action automation.
+WEBHOOK_EVENT_ENTRYPOINT_BOUNDARY = "sandbox-provider-observation-only"
 
 router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 

--- a/core/after_commit_actions.py
+++ b/core/after_commit_actions.py
@@ -2,6 +2,8 @@
 
 Actions here must finish before the producer API call returns. External events
 such as hook failures or scheduler ticks are not after-commit actions.
+`backend.web.routers.webhooks` is sandbox provider observation, not a shortcut
+around that boundary.
 """
 
 from __future__ import annotations

--- a/tests/Unit/integration_contracts/test_webhooks_router_contract.py
+++ b/tests/Unit/integration_contracts/test_webhooks_router_contract.py
@@ -1,8 +1,41 @@
 from __future__ import annotations
 
+from types import ModuleType
+
 import pytest
 
 from backend.web.routers import webhooks
+
+
+def _module_name(value: object) -> str | None:
+    module_name = getattr(value, "__module__", None)
+    if isinstance(module_name, str):
+        return module_name
+    if isinstance(value, ModuleType):
+        return value.__name__
+    return None
+
+
+def test_provider_webhooks_are_not_mycel_event_action_entrypoint() -> None:
+    assert webhooks.WEBHOOK_EVENT_ENTRYPOINT_BOUNDARY == "sandbox-provider-observation-only"
+    assert "sandbox provider observation only" in (webhooks.__doc__ or "").lower()
+
+    forbidden_modules = (
+        "backend.messaging",
+        "backend.threads.chat_adapters.runtime_notification_action",
+        "backend.threads.chat_adapters.runtime_chat_delivery_action",
+        "core.after_commit_actions",
+        "messaging.service",
+    )
+    offenders = {
+        name: module_name
+        for name, value in vars(webhooks).items()
+        if not name.startswith("__")
+        if (module_name := _module_name(value)) is not None
+        if module_name.startswith(forbidden_modules)
+    }
+
+    assert offenders == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Declare `/api/webhooks` as sandbox provider observation only, not a Mycel event/action entrypoint.
- Add an integration contract that rejects chat/messaging/runtime notification/AfterCommitActions dependencies from the provider webhook router.
- Cross-reference that boundary from `AfterCommitActions`.

## Tests
- `uv run pytest tests/Unit/integration_contracts/test_webhooks_router_contract.py tests/Unit/core/test_after_commit_actions.py -q`
- `uv run ruff check backend/web/routers/webhooks.py core/after_commit_actions.py tests/Unit/integration_contracts/test_webhooks_router_contract.py tests/Unit/core/test_after_commit_actions.py`
- `uv run ruff format --check backend/web/routers/webhooks.py core/after_commit_actions.py tests/Unit/integration_contracts/test_webhooks_router_contract.py tests/Unit/core/test_after_commit_actions.py`
- `uv run pyright backend/web/routers/webhooks.py core/after_commit_actions.py tests/Unit/integration_contracts/test_webhooks_router_contract.py tests/Unit/core/test_after_commit_actions.py`
- `uv run pytest tests/Unit -q`
