### PR TITLE
Verify workflow state version on staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -123,7 +123,13 @@ jobs:
             echo "openapi attempt ${attempt}: status=${status}"
             if [ "$status" = "200" ]; then
               cat /tmp/staging-openapi.json
-              jq -e '.openapi and .info.title == "Mycel Web Backend" and (.paths | has("/api/runtime/inbox/wait"))' /tmp/staging-openapi.json >/dev/null
+              jq -e '
+                .openapi
+                and .info.title == "Mycel Web Backend"
+                and (.paths | has("/api/runtime/inbox/wait"))
+                and (.components.schemas.SetChatWorkflowBody.properties | has("expected_state_version"))
+                and (.components.schemas.UpdateChatWorkflowEventBody.properties | has("expected_state_version"))
+              ' /tmp/staging-openapi.json >/dev/null
               exit 0
             fi
             cat /tmp/staging-openapi.json || true


### PR DESCRIPTION
## Summary
- tighten the staging deploy OpenAPI check so it must expose workflow state-version request fields
- catch stale backend deploys that still lack `expected_state_version` before we call staging healthy

## Verification
- `uv run python scripts/check_app_schema.py`
- generated local FastAPI OpenAPI and ran the same `jq` contract check against it

## Context
The current staging/prod deployment is on an older app commit and lacks the workflow `state_version` contract. This PR does not perform the deploy or schema migration; it makes the staging deploy workflow fail loudly if that contract is still absent after deployment.
