### PR TITLE
Unify runtime action dispatch boundary

### DIFF
--- a/backend/threads/chat_adapters/chat_inlet.py
+++ b/backend/threads/chat_adapters/chat_inlet.py
@@ -4,12 +4,13 @@ from collections.abc import Iterable
 from typing import Any
 
 from backend.threads.chat_adapters.chat_notification_format import format_chat_notification
-from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction, make_runtime_notification_event_hook
+from backend.threads.chat_adapters.runtime_action import make_runtime_action_event_hook
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
 from messaging.delivery.contracts import ChatDeliveryRequest
 
 
 def make_chat_delivery_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    return make_runtime_notification_event_hook(
+    return make_runtime_action_event_hook(
         app,
         chat_delivery_runtime_notification_actions,
         thread_repo=thread_repo,

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from backend.threads.chat_adapters.runtime_action import make_runtime_action_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
-from backend.threads.chat_adapters.runtime_notification_action import (
-    RuntimeNotificationAction,
-    make_runtime_notification_event_hook,
-)
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = chat_join_rejection_notification_action_planner(user_repo)
-    return make_runtime_notification_event_hook(
+    return make_runtime_action_event_hook(
         app,
         planner,
         user_repo=user_repo,

--- a/backend/threads/chat_adapters/chat_join_inlet.py
+++ b/backend/threads/chat_adapters/chat_join_inlet.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from backend.threads.chat_adapters.runtime_action import make_runtime_action_event_hook
@@ -9,21 +8,16 @@ from backend.threads.chat_adapters.runtime_notification_action import RuntimeNot
 
 
 def make_chat_join_rejection_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    planner = chat_join_rejection_notification_action_planner(user_repo)
+    def plan(row: dict[str, Any]) -> list[RuntimeNotificationAction]:
+        return [chat_join_rejection_notification_action(row, user_repo=user_repo)]
+
     return make_runtime_action_event_hook(
         app,
-        planner,
+        plan,
         user_repo=user_repo,
         thread_repo=thread_repo,
         activity_reader=activity_reader,
     )
-
-
-def chat_join_rejection_notification_action_planner(user_repo: Any) -> Callable[[dict[str, Any]], list[RuntimeNotificationAction]]:
-    def plan(row: dict[str, Any]) -> list[RuntimeNotificationAction]:
-        return [chat_join_rejection_notification_action(row, user_repo=user_repo)]
-
-    return plan
 
 
 def chat_join_rejection_notification_action(row: dict[str, Any], *, user_repo: Any) -> RuntimeNotificationAction:

--- a/backend/threads/chat_adapters/queued_thread_input_action.py
+++ b/backend/threads/chat_adapters/queued_thread_input_action.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class QueuedThreadInputAction:
+    thread_id: str
+    content: str
+    notification_type: str = "steer"
+
+
+def queued_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadInputAction:
+    return QueuedThreadInputAction(thread_id=thread_id, content=message)
+
+
+def queued_command_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadInputAction:
+    return QueuedThreadInputAction(thread_id=thread_id, content=message, notification_type="command")
+
+
+def dispatch_queued_thread_input_action(queue_manager: Any, action: QueuedThreadInputAction) -> dict[str, str]:
+    queue_manager.enqueue(action.content, action.thread_id, notification_type=action.notification_type)
+    return {"status": "queued", "thread_id": action.thread_id}

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -4,11 +4,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from backend.threads.chat_adapters.runtime_action import make_runtime_action_event_hook
 from backend.threads.chat_adapters.runtime_identity import display_name, require_user
-from backend.threads.chat_adapters.runtime_notification_action import (
-    RuntimeNotificationAction,
-    make_runtime_notification_event_hook,
-)
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
 from messaging.contracts import RelationshipEvent, RelationshipRow
 
 _DECISION_VERBS: dict[RelationshipEvent, str] = {
@@ -25,7 +23,7 @@ class RelationshipDecisionChange:
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = relationship_request_notification_action_planner(user_repo)
-    return make_runtime_notification_event_hook(
+    return make_runtime_action_event_hook(
         app,
         planner,
         user_repo=user_repo,
@@ -63,7 +61,7 @@ def relationship_request_notification_action(row: RelationshipRow, *, user_repo:
 
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
     planner = relationship_decision_notification_action_planner(user_repo)
-    planned_hook = make_runtime_notification_event_hook(
+    planned_hook = make_runtime_action_event_hook(
         app,
         planner,
         user_repo=user_repo,

--- a/backend/threads/chat_adapters/relationship_inlet.py
+++ b/backend/threads/chat_adapters/relationship_inlet.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -22,21 +21,16 @@ class RelationshipDecisionChange:
 
 
 def make_relationship_request_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    planner = relationship_request_notification_action_planner(user_repo)
+    def plan(row: RelationshipRow) -> list[RuntimeNotificationAction]:
+        return [relationship_request_notification_action(row, user_repo=user_repo)]
+
     return make_runtime_action_event_hook(
         app,
-        planner,
+        plan,
         user_repo=user_repo,
         thread_repo=thread_repo,
         activity_reader=activity_reader,
     )
-
-
-def relationship_request_notification_action_planner(user_repo: Any) -> Callable[[RelationshipRow], list[RuntimeNotificationAction]]:
-    def plan(row: RelationshipRow) -> list[RuntimeNotificationAction]:
-        return [relationship_request_notification_action(row, user_repo=user_repo)]
-
-    return plan
 
 
 def relationship_request_notification_action(row: RelationshipRow, *, user_repo: Any) -> RuntimeNotificationAction:
@@ -60,10 +54,12 @@ def relationship_request_notification_action(row: RelationshipRow, *, user_repo:
 
 
 def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any, thread_repo: Any, user_repo: Any):
-    planner = relationship_decision_notification_action_planner(user_repo)
+    def plan(change: RelationshipDecisionChange) -> list[RuntimeNotificationAction]:
+        return [relationship_decision_notification_action(change, user_repo=user_repo)]
+
     planned_hook = make_runtime_action_event_hook(
         app,
-        planner,
+        plan,
         user_repo=user_repo,
         thread_repo=thread_repo,
         activity_reader=activity_reader,
@@ -73,15 +69,6 @@ def make_relationship_decision_notification_fn(app: Any, *, activity_reader: Any
         planned_hook(RelationshipDecisionChange(row=row, event=event))
 
     return notify_runtime
-
-
-def relationship_decision_notification_action_planner(
-    user_repo: Any,
-) -> Callable[[RelationshipDecisionChange], list[RuntimeNotificationAction]]:
-    def plan(change: RelationshipDecisionChange) -> list[RuntimeNotificationAction]:
-        return [relationship_decision_notification_action(change, user_repo=user_repo)]
-
-    return plan
 
 
 def relationship_decision_notification_action(change: RelationshipDecisionChange, *, user_repo: Any) -> RuntimeNotificationAction:

--- a/backend/threads/chat_adapters/runtime_action.py
+++ b/backend/threads/chat_adapters/runtime_action.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from backend.threads.chat_adapters.port import get_agent_runtime_gateway
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction, plan_runtime_notification_envelope
+from backend.threads.chat_adapters.runtime_sync_event_hook import make_blocking_runtime_event_hook
+from backend.threads.chat_adapters.runtime_thread_input_action import RuntimeThreadInputAction, plan_runtime_thread_input_envelope
+from protocols.agent_runtime import (
+    AgentRuntimeNotificationEnvelope,
+    AgentRuntimeNotificationResult,
+    AgentThreadInputEnvelope,
+    AgentThreadInputResult,
+)
+
+RuntimeAction = RuntimeNotificationAction | RuntimeThreadInputAction
+RuntimeActionEnvelope = AgentRuntimeNotificationEnvelope | AgentThreadInputEnvelope
+RuntimeActionResult = AgentRuntimeNotificationResult | AgentThreadInputResult
+
+
+def make_runtime_action_event_hook[EventT](
+    app: Any,
+    planner: Callable[[EventT], Iterable[RuntimeAction]],
+    *,
+    user_repo: Any,
+    thread_repo: Any,
+    activity_reader: Any,
+) -> Callable[[EventT], None]:
+    async def dispatch_event(event: EventT) -> int:
+        return await dispatch_runtime_actions(
+            app,
+            planner(event),
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+
+    return make_blocking_runtime_event_hook(dispatch_event)
+
+
+async def dispatch_runtime_actions(
+    app: Any,
+    actions: Iterable[RuntimeAction],
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> int:
+    gateway = None
+    dispatched_count = 0
+    for action in actions:
+        envelope = plan_runtime_action_envelope(
+            action,
+            user_repo=user_repo,
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+        if envelope is None:
+            continue
+        if gateway is None:
+            gateway = get_agent_runtime_gateway(app)
+        await dispatch_runtime_action_envelope(gateway, envelope)
+        dispatched_count += 1
+    return dispatched_count
+
+
+async def dispatch_runtime_action(
+    app: Any,
+    action: RuntimeAction,
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> RuntimeActionResult | None:
+    envelope = plan_runtime_action_envelope(
+        action,
+        user_repo=user_repo,
+        thread_repo=thread_repo,
+        activity_reader=activity_reader,
+    )
+    if envelope is None:
+        return None
+    return await dispatch_runtime_action_envelope(get_agent_runtime_gateway(app), envelope)
+
+
+def plan_runtime_action_envelope(
+    action: RuntimeAction,
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> RuntimeActionEnvelope | None:
+    # @@@runtime-action-boundary - actions plan backend context into runtime envelopes; gateways only dispatch envelopes.
+    if isinstance(action, RuntimeNotificationAction):
+        return plan_runtime_notification_envelope(
+            action,
+            user_repo=_required_dependency(user_repo, "user_repo", action),
+            thread_repo=thread_repo,
+            activity_reader=activity_reader,
+        )
+    if isinstance(action, RuntimeThreadInputAction):
+        return plan_runtime_thread_input_envelope(action)
+    raise TypeError(f"Unsupported runtime action: {type(action).__name__}")
+
+
+async def dispatch_runtime_action_envelope(gateway: Any, envelope: RuntimeActionEnvelope) -> RuntimeActionResult:
+    if isinstance(envelope, AgentRuntimeNotificationEnvelope):
+        return await gateway.dispatch_notification(envelope)
+    if isinstance(envelope, AgentThreadInputEnvelope):
+        return await gateway.dispatch_thread_input(envelope)
+    raise TypeError(f"Unsupported runtime action envelope: {type(envelope).__name__}")
+
+
+def _required_dependency(value: Any, name: str, action: RuntimeNotificationAction) -> Any:
+    if value is None:
+        raise RuntimeError(f"{action.context} needs {name} to plan runtime notification action")
+    return value

--- a/backend/threads/chat_adapters/runtime_action.py
+++ b/backend/threads/chat_adapters/runtime_action.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, overload
 
 from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction, plan_runtime_notification_envelope
@@ -63,6 +63,28 @@ async def dispatch_runtime_actions(
         await dispatch_runtime_action_envelope(gateway, envelope)
         dispatched_count += 1
     return dispatched_count
+
+
+@overload
+async def dispatch_runtime_action(
+    app: Any,
+    action: RuntimeThreadInputAction,
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> AgentThreadInputResult: ...
+
+
+@overload
+async def dispatch_runtime_action(
+    app: Any,
+    action: RuntimeNotificationAction,
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> AgentRuntimeNotificationResult | None: ...
 
 
 async def dispatch_runtime_action(

--- a/backend/threads/chat_adapters/runtime_action.py
+++ b/backend/threads/chat_adapters/runtime_action.py
@@ -106,6 +106,26 @@ async def dispatch_runtime_action(
     return await dispatch_runtime_action_envelope(get_agent_runtime_gateway(app), envelope)
 
 
+@overload
+def plan_runtime_action_envelope(
+    action: RuntimeThreadInputAction,
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> AgentThreadInputEnvelope: ...
+
+
+@overload
+def plan_runtime_action_envelope(
+    action: RuntimeNotificationAction,
+    *,
+    user_repo: Any = None,
+    thread_repo: Any = None,
+    activity_reader: Any = None,
+) -> AgentRuntimeNotificationEnvelope | None: ...
+
+
 def plan_runtime_action_envelope(
     action: RuntimeAction,
     *,

--- a/backend/threads/chat_adapters/runtime_notification_action.py
+++ b/backend/threads/chat_adapters/runtime_notification_action.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_identity import make_runtime_actor, require_user
 from backend.threads.chat_adapters.runtime_recipient import resolve_runtime_notification_recipient
-from backend.threads.chat_adapters.runtime_sync_event_hook import make_blocking_runtime_event_hook
 from protocols.agent_runtime import (
     AgentRuntimeMessage,
     AgentRuntimeNotificationEnvelope,
@@ -29,52 +26,6 @@ class RuntimeNotificationAction:
     transport: AgentRuntimeTransport = AgentRuntimeTransport()
     include_sender_avatar: bool = False
     runtime_context: str | None = None
-
-
-def make_runtime_notification_event_hook[EventT](
-    app: Any,
-    planner: Callable[[EventT], Iterable[RuntimeNotificationAction]],
-    *,
-    user_repo: Any,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> Callable[[EventT], None]:
-    async def dispatch_event(event: EventT) -> int:
-        return await dispatch_runtime_notification_actions(
-            app,
-            planner(event),
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-
-    return make_blocking_runtime_event_hook(dispatch_event)
-
-
-async def dispatch_runtime_notification_actions(
-    app: Any,
-    actions: Iterable[RuntimeNotificationAction],
-    *,
-    user_repo: Any,
-    thread_repo: Any,
-    activity_reader: Any,
-) -> int:
-    gateway = None
-    dispatched_count = 0
-    for action in actions:
-        envelope = plan_runtime_notification_envelope(
-            action,
-            user_repo=user_repo,
-            thread_repo=thread_repo,
-            activity_reader=activity_reader,
-        )
-        if envelope is None:
-            continue
-        if gateway is None:
-            gateway = get_agent_runtime_gateway(app)
-        await gateway.dispatch_notification(envelope)
-        dispatched_count += 1
-    return dispatched_count
 
 
 def plan_runtime_notification_envelope(

--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from backend.threads.chat_adapters.port import get_agent_runtime_gateway
 from backend.threads.chat_adapters.runtime_identity import runtime_actor
-from protocols.agent_runtime import AgentRuntimeMessage, AgentThreadInputEnvelope, AgentThreadInputResult
+from protocols.agent_runtime import AgentRuntimeMessage, AgentThreadInputEnvelope
 
 
 @dataclass(frozen=True)
@@ -77,11 +76,6 @@ def internal_runtime_thread_input_action(
         content=message,
         metadata=metadata,
     )
-
-
-async def dispatch_runtime_thread_input_action(app: Any, action: RuntimeThreadInputAction) -> AgentThreadInputResult:
-    gateway = get_agent_runtime_gateway(app)
-    return await gateway.dispatch_thread_input(plan_runtime_thread_input_envelope(action))
 
 
 def plan_runtime_thread_input_envelope(action: RuntimeThreadInputAction) -> AgentThreadInputEnvelope:

--- a/backend/threads/chat_adapters/runtime_thread_input_action.py
+++ b/backend/threads/chat_adapters/runtime_thread_input_action.py
@@ -20,26 +20,6 @@ class RuntimeThreadInputAction:
     enable_trajectory: bool = False
 
 
-@dataclass(frozen=True)
-class QueuedThreadInputAction:
-    thread_id: str
-    content: str
-    notification_type: str = "steer"
-
-
-def queued_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadInputAction:
-    return QueuedThreadInputAction(thread_id=thread_id, content=message)
-
-
-def queued_command_thread_input_action(*, thread_id: str, message: str) -> QueuedThreadInputAction:
-    return QueuedThreadInputAction(thread_id=thread_id, content=message, notification_type="command")
-
-
-def dispatch_queued_thread_input_action(queue_manager: Any, action: QueuedThreadInputAction) -> dict[str, str]:
-    queue_manager.enqueue(action.content, action.thread_id, notification_type=action.notification_type)
-    return {"status": "queued", "thread_id": action.thread_id}
-
-
 def owner_runtime_thread_input_action(
     *,
     thread_id: str,

--- a/backend/threads/chat_adapters/thread_input_inlet.py
+++ b/backend/threads/chat_adapters/thread_input_inlet.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.threads.chat_adapters.runtime_action import dispatch_runtime_action
 from backend.threads.chat_adapters.runtime_thread_input_action import (
+    RuntimeThreadInputAction,
     dispatch_queued_thread_input_action,
-    dispatch_runtime_thread_input_action,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
     queued_command_thread_input_action,
@@ -22,9 +23,9 @@ async def dispatch_owner_thread_input(
     attachments: list[str] | None,
     enable_trajectory: bool,
 ) -> AgentThreadInputResult:
-    return await dispatch_runtime_thread_input_action(
+    return await _dispatch_thread_input_action(
         app,
-        owner_runtime_thread_input_action(
+        action=owner_runtime_thread_input_action(
             thread_id=thread_id,
             user_id=user_id,
             message=message,
@@ -42,15 +43,22 @@ async def dispatch_internal_thread_input(
     message: str,
     metadata: dict[str, Any] | None = None,
 ) -> AgentThreadInputResult:
-    return await dispatch_runtime_thread_input_action(
+    return await _dispatch_thread_input_action(
         app,
-        internal_runtime_thread_input_action(
+        action=internal_runtime_thread_input_action(
             thread_id=thread_id,
             user_id=user_id,
             message=message,
             metadata=metadata,
         ),
     )
+
+
+async def _dispatch_thread_input_action(app: Any, *, action: RuntimeThreadInputAction) -> AgentThreadInputResult:
+    result = await dispatch_runtime_action(app, action)
+    if not isinstance(result, AgentThreadInputResult):
+        raise RuntimeError("Runtime thread input action did not return a thread input result")
+    return result
 
 
 def queue_thread_input(queue_manager: Any, *, thread_id: str, message: str) -> dict[str, str]:

--- a/backend/threads/chat_adapters/thread_input_inlet.py
+++ b/backend/threads/chat_adapters/thread_input_inlet.py
@@ -9,7 +9,6 @@ from backend.threads.chat_adapters.queued_thread_input_action import (
 )
 from backend.threads.chat_adapters.runtime_action import dispatch_runtime_action
 from backend.threads.chat_adapters.runtime_thread_input_action import (
-    RuntimeThreadInputAction,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
 )
@@ -25,9 +24,9 @@ async def dispatch_owner_thread_input(
     attachments: list[str] | None,
     enable_trajectory: bool,
 ) -> AgentThreadInputResult:
-    return await _dispatch_thread_input_action(
+    return await dispatch_runtime_action(
         app,
-        action=owner_runtime_thread_input_action(
+        owner_runtime_thread_input_action(
             thread_id=thread_id,
             user_id=user_id,
             message=message,
@@ -45,22 +44,15 @@ async def dispatch_internal_thread_input(
     message: str,
     metadata: dict[str, Any] | None = None,
 ) -> AgentThreadInputResult:
-    return await _dispatch_thread_input_action(
+    return await dispatch_runtime_action(
         app,
-        action=internal_runtime_thread_input_action(
+        internal_runtime_thread_input_action(
             thread_id=thread_id,
             user_id=user_id,
             message=message,
             metadata=metadata,
         ),
     )
-
-
-async def _dispatch_thread_input_action(app: Any, *, action: RuntimeThreadInputAction) -> AgentThreadInputResult:
-    result = await dispatch_runtime_action(app, action)
-    if not isinstance(result, AgentThreadInputResult):
-        raise RuntimeError("Runtime thread input action did not return a thread input result")
-    return result
 
 
 def queue_thread_input(queue_manager: Any, *, thread_id: str, message: str) -> dict[str, str]:

--- a/backend/threads/chat_adapters/thread_input_inlet.py
+++ b/backend/threads/chat_adapters/thread_input_inlet.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.threads.chat_adapters.queued_thread_input_action import (
+    dispatch_queued_thread_input_action,
+    queued_command_thread_input_action,
+    queued_thread_input_action,
+)
 from backend.threads.chat_adapters.runtime_action import dispatch_runtime_action
 from backend.threads.chat_adapters.runtime_thread_input_action import (
     RuntimeThreadInputAction,
-    dispatch_queued_thread_input_action,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
-    queued_command_thread_input_action,
-    queued_thread_input_action,
 )
 from protocols.agent_runtime import AgentThreadInputResult
 

--- a/backend/threads/chat_adapters/workflow_event_inlet.py
+++ b/backend/threads/chat_adapters/workflow_event_inlet.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
-from backend.threads.chat_adapters.runtime_notification_action import (
-    RuntimeNotificationAction,
-    make_runtime_notification_event_hook,
-)
+from backend.threads.chat_adapters.runtime_action import make_runtime_action_event_hook
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
 from core.work_item.chat_workflow.service import WorkflowEventChange
 from protocols.agent_runtime import AgentRuntimeTransport
 
@@ -20,7 +18,7 @@ def make_workflow_event_notification_fn(
     messaging_service: Any,
 ) -> Callable[[WorkflowEventChange], None]:
     planner = workflow_event_notification_action_planner(messaging_service)
-    return make_runtime_notification_event_hook(
+    return make_runtime_action_event_hook(
         app,
         planner,
         user_repo=user_repo,

--- a/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_chat_join_request_notification_hook.py
@@ -62,14 +62,11 @@ def _only_envelope(gateway: _RecordingGateway):
     return gateway.envelopes[0]
 
 
-def test_chat_join_rejection_notification_planner_returns_runtime_action() -> None:
+def test_chat_join_rejection_notification_action_carries_runtime_contract() -> None:
     user_repo = _user_repo(_user("owner-1", "human", "Owner"))
-    planner = chat_join_inlet.chat_join_rejection_notification_action_planner(user_repo)
 
-    actions = planner(_join_request())
+    action = chat_join_inlet.chat_join_rejection_notification_action(_join_request(), user_repo=user_repo)
 
-    assert len(actions) == 1
-    action = actions[0]
     assert action.context == "Chat join rejection"
     assert action.recipient_user_id == "agent-user-1"
     assert action.sender_user_id == "owner-1"

--- a/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
+++ b/tests/Unit/backend/web/services/test_relationship_request_notification_hook.py
@@ -76,14 +76,14 @@ def _only_envelope(gateway: _RecordingGateway):
     return gateway.envelopes[0]
 
 
-def test_relationship_request_notification_planner_returns_runtime_action() -> None:
+def test_relationship_request_notification_action_carries_runtime_contract() -> None:
     user_repo = _user_repo(_user("human-user-1", "human", "Human"))
-    planner = relationship_inlet.relationship_request_notification_action_planner(user_repo)
 
-    actions = planner(_relationship_row(message="Please add me."))
+    action = relationship_inlet.relationship_request_notification_action(
+        _relationship_row(message="Please add me."),
+        user_repo=user_repo,
+    )
 
-    assert len(actions) == 1
-    action = actions[0]
     assert action.context == "Relationship request"
     assert action.recipient_user_id == "agent-user-1"
     assert action.sender_user_id == "human-user-1"
@@ -98,19 +98,17 @@ def test_relationship_request_notification_planner_returns_runtime_action() -> N
     assert action.include_sender_avatar is True
 
 
-def test_relationship_decision_notification_planner_returns_runtime_action() -> None:
+def test_relationship_decision_notification_action_carries_runtime_contract() -> None:
     user_repo = _user_repo(_user("human-user-1", "human", "Human"))
-    planner = relationship_inlet.relationship_decision_notification_action_planner(user_repo)
 
-    actions = planner(
+    action = relationship_inlet.relationship_decision_notification_action(
         relationship_inlet.RelationshipDecisionChange(
             row=_relationship_row(initiator_user_id="agent-user-1", state="visit"),
             event="approve",
-        )
+        ),
+        user_repo=user_repo,
     )
 
-    assert len(actions) == 1
-    action = actions[0]
     assert action.context == "Relationship request"
     assert action.recipient_user_id == "agent-user-1"
     assert action.sender_user_id == "human-user-1"

--- a/tests/Unit/backend/web/services/test_runtime_action_dispatcher.py
+++ b/tests/Unit/backend/web/services/test_runtime_action_dispatcher.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.threads.chat_adapters.runtime_action import dispatch_runtime_action, dispatch_runtime_actions
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
+from backend.threads.chat_adapters.runtime_thread_input_action import owner_runtime_thread_input_action
+from protocols.agent_runtime import AgentRuntimeNotificationResult, AgentThreadInputResult
+
+
+def _runtime_app(gateway: object) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(threads_runtime_state=SimpleNamespace(agent_runtime_gateway=gateway)))
+
+
+def _users() -> SimpleNamespace:
+    rows = {
+        "owner-1": SimpleNamespace(id="owner-1", type="human", display_name="Owner", avatar=None),
+        "agent-1": SimpleNamespace(id="agent-1", type="agent", display_name="Worker", avatar=None),
+    }
+    return SimpleNamespace(get_by_id=lambda user_id: rows.get(user_id))
+
+
+def _thread_repo() -> SimpleNamespace:
+    thread = {"id": "thread-agent-1", "agent_user_id": "agent-1", "is_main": True, "branch_index": 0}
+    return SimpleNamespace(
+        get_by_user_id=lambda user_id: thread if user_id == "agent-1" else None,
+        list_by_agent_user=lambda user_id: [thread] if user_id == "agent-1" else [],
+    )
+
+
+def _activity_reader() -> SimpleNamespace:
+    return SimpleNamespace(list_active_threads_for_agent=lambda _agent_user_id: [])
+
+
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.notifications = []
+        self.thread_inputs = []
+
+    async def dispatch_notification(self, envelope):
+        self.notifications.append(envelope)
+        return AgentRuntimeNotificationResult(status="accepted", thread_id=envelope.recipient.thread_id)
+
+    async def dispatch_thread_input(self, envelope):
+        self.thread_inputs.append(envelope)
+        return AgentThreadInputResult(status="started", routing="direct", thread_id=envelope.thread_id)
+
+
+@pytest.mark.asyncio
+async def test_runtime_action_dispatches_notification_and_thread_input_actions_through_one_boundary() -> None:
+    gateway = _RecordingGateway()
+    notification = RuntimeNotificationAction(
+        context="Runtime action test",
+        recipient_user_id="agent-1",
+        sender_user_id="owner-1",
+        sender_source="workflow",
+        event_type="test.event",
+        notification_type="test",
+        content="Notify worker.",
+    )
+    thread_input = owner_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="Direct input.",
+        attachments=None,
+        enable_trajectory=True,
+    )
+
+    count = await dispatch_runtime_actions(
+        _runtime_app(gateway),
+        [notification, thread_input],
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=_activity_reader(),
+    )
+
+    assert count == 2
+    assert gateway.notifications[0].event_type == "test.event"
+    assert gateway.thread_inputs[0].thread_id == "thread-1"
+    assert gateway.thread_inputs[0].enable_trajectory is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_action_returns_thread_input_result() -> None:
+    gateway = _RecordingGateway()
+
+    result = await dispatch_runtime_action(
+        _runtime_app(gateway),
+        owner_runtime_thread_input_action(
+            thread_id="thread-1",
+            user_id="owner-1",
+            message="Direct input.",
+            attachments=None,
+            enable_trajectory=False,
+        ),
+    )
+
+    assert result == AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")

--- a/tests/Unit/backend/web/services/test_runtime_action_dispatcher.py
+++ b/tests/Unit/backend/web/services/test_runtime_action_dispatcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import assert_type
 
 import pytest
 
@@ -97,4 +98,5 @@ async def test_runtime_action_returns_thread_input_result() -> None:
         ),
     )
 
+    assert_type(result, AgentThreadInputResult)
     assert result == AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")

--- a/tests/Unit/backend/web/services/test_runtime_action_dispatcher.py
+++ b/tests/Unit/backend/web/services/test_runtime_action_dispatcher.py
@@ -5,10 +5,15 @@ from typing import assert_type
 
 import pytest
 
-from backend.threads.chat_adapters.runtime_action import dispatch_runtime_action, dispatch_runtime_actions
+from backend.threads.chat_adapters.runtime_action import dispatch_runtime_action, dispatch_runtime_actions, plan_runtime_action_envelope
 from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
 from backend.threads.chat_adapters.runtime_thread_input_action import owner_runtime_thread_input_action
-from protocols.agent_runtime import AgentRuntimeNotificationResult, AgentThreadInputResult
+from protocols.agent_runtime import (
+    AgentRuntimeNotificationEnvelope,
+    AgentRuntimeNotificationResult,
+    AgentThreadInputEnvelope,
+    AgentThreadInputResult,
+)
 
 
 def _runtime_app(gateway: object) -> SimpleNamespace:
@@ -100,3 +105,36 @@ async def test_runtime_action_returns_thread_input_result() -> None:
 
     assert_type(result, AgentThreadInputResult)
     assert result == AgentThreadInputResult(status="started", routing="direct", thread_id="thread-1")
+
+
+def test_runtime_action_planner_exposes_specific_envelope_types() -> None:
+    thread_input = owner_runtime_thread_input_action(
+        thread_id="thread-1",
+        user_id="owner-1",
+        message="Direct input.",
+        attachments=None,
+        enable_trajectory=False,
+    )
+    notification = RuntimeNotificationAction(
+        context="Runtime action test",
+        recipient_user_id="agent-1",
+        sender_user_id="owner-1",
+        sender_source="workflow",
+        event_type="test.event",
+        notification_type="test",
+        content="Notify worker.",
+    )
+
+    thread_envelope = plan_runtime_action_envelope(thread_input)
+    notification_envelope = plan_runtime_action_envelope(
+        notification,
+        user_repo=_users(),
+        thread_repo=_thread_repo(),
+        activity_reader=_activity_reader(),
+    )
+
+    assert_type(thread_envelope, AgentThreadInputEnvelope)
+    assert_type(notification_envelope, AgentRuntimeNotificationEnvelope | None)
+    assert thread_envelope.thread_id == "thread-1"
+    assert notification_envelope is not None
+    assert notification_envelope.event_type == "test.event"

--- a/tests/Unit/backend/web/services/test_runtime_notification_action.py
+++ b/tests/Unit/backend/web/services/test_runtime_notification_action.py
@@ -6,11 +6,8 @@ from typing import Any
 
 import pytest
 
-from backend.threads.chat_adapters.runtime_notification_action import (
-    RuntimeNotificationAction,
-    dispatch_runtime_notification_actions,
-    make_runtime_notification_event_hook,
-)
+from backend.threads.chat_adapters.runtime_action import dispatch_runtime_actions, make_runtime_action_event_hook
+from backend.threads.chat_adapters.runtime_notification_action import RuntimeNotificationAction
 from protocols.agent_runtime import AgentRuntimeTransport
 
 
@@ -65,7 +62,7 @@ def _action(**overrides) -> RuntimeNotificationAction:
 async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_recipient() -> None:
     gateway = _RecordingGateway()
 
-    dispatched_count = await dispatch_runtime_notification_actions(
+    dispatched_count = await dispatch_runtime_actions(
         _runtime_app(gateway),
         [
             _action(
@@ -101,7 +98,7 @@ async def test_runtime_notification_action_resolves_and_dispatches_to_runtime_re
 async def test_runtime_notification_actions_dispatches_only_runtime_recipients() -> None:
     gateway = _RecordingGateway()
 
-    dispatched_count = await dispatch_runtime_notification_actions(
+    dispatched_count = await dispatch_runtime_actions(
         _runtime_app(gateway),
         [
             _action(),
@@ -125,7 +122,7 @@ async def test_runtime_notification_hook_plans_and_dispatches_actions() -> None:
     def planner(value: str) -> list[RuntimeNotificationAction]:
         return [_action(context="Test hook", content=f"Action {value}.")]
 
-    hook = make_runtime_notification_event_hook(
+    hook = make_runtime_action_event_hook(
         _runtime_app(gateway),
         planner,
         user_repo=_users(),

--- a/tests/Unit/integration_contracts/test_threads_router.py
+++ b/tests/Unit/integration_contracts/test_threads_router.py
@@ -13,15 +13,17 @@ import pytest
 from fastapi import Request
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 
-from backend.threads.chat_adapters.runtime_thread_input_action import (
+from backend.threads.chat_adapters.queued_thread_input_action import (
     QueuedThreadInputAction,
-    RuntimeThreadInputAction,
     dispatch_queued_thread_input_action,
+    queued_command_thread_input_action,
+    queued_thread_input_action,
+)
+from backend.threads.chat_adapters.runtime_thread_input_action import (
+    RuntimeThreadInputAction,
     internal_runtime_thread_input_action,
     owner_runtime_thread_input_action,
     plan_runtime_thread_input_envelope,
-    queued_command_thread_input_action,
-    queued_thread_input_action,
 )
 from backend.threads.chat_adapters.thread_input_inlet import requeue_thread_input_item
 from backend.web.models.requests import CreateThreadRequest, ResolvePermissionRequest, SendMessageRequest, ThreadPermissionRuleRequest


### PR DESCRIPTION
## Summary

- unify runtime notification and runtime thread-input dispatch through `runtime_action.py`
- remove trivial one-action planner wrappers and split queued thread-input actions out of runtime-gateway actions
- add overload-backed type contracts for action dispatch results and envelope planning

## Verification

- `uv run pytest tests/Unit/backend/web/services/test_runtime_action_dispatcher.py tests/Unit/backend/web/services/test_runtime_notification_action.py tests/Unit/integration_contracts/test_threads_router.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_action.py tests/Unit/backend/web/services/test_runtime_action_dispatcher.py`
- `uv run pyright backend/threads/chat_adapters/runtime_action.py tests/Unit/backend/web/services/test_runtime_action_dispatcher.py`
- `uv run pytest tests/Unit/backend tests/Unit/integration_contracts -q`

## Notes

- five coherent commits are preserved for review
- no DSL, scheduler, retry queue, schema change, local daemon, polling, or transport change
