### PR TITLE
Hide runtime action envelope dispatch helper

### DIFF
--- a/backend/threads/chat_adapters/runtime_action.py
+++ b/backend/threads/chat_adapters/runtime_action.py
@@ -60,7 +60,7 @@ async def dispatch_runtime_actions(
             continue
         if gateway is None:
             gateway = get_agent_runtime_gateway(app)
-        await dispatch_runtime_action_envelope(gateway, envelope)
+        await _dispatch_runtime_action_envelope(gateway, envelope)
         dispatched_count += 1
     return dispatched_count
 
@@ -103,7 +103,7 @@ async def dispatch_runtime_action(
     )
     if envelope is None:
         return None
-    return await dispatch_runtime_action_envelope(get_agent_runtime_gateway(app), envelope)
+    return await _dispatch_runtime_action_envelope(get_agent_runtime_gateway(app), envelope)
 
 
 @overload
@@ -146,7 +146,7 @@ def plan_runtime_action_envelope(
     raise TypeError(f"Unsupported runtime action: {type(action).__name__}")
 
 
-async def dispatch_runtime_action_envelope(gateway: Any, envelope: RuntimeActionEnvelope) -> RuntimeActionResult:
+async def _dispatch_runtime_action_envelope(gateway: Any, envelope: RuntimeActionEnvelope) -> RuntimeActionResult:
     if isinstance(envelope, AgentRuntimeNotificationEnvelope):
         return await gateway.dispatch_notification(envelope)
     if isinstance(envelope, AgentThreadInputEnvelope):

--- a/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
+++ b/tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py
@@ -138,9 +138,11 @@ def test_chat_delivery_adapter_is_not_a_separate_runtime_action_module() -> None
 
 
 def test_runtime_action_adapters_do_not_export_envelope_dispatch_helpers() -> None:
+    runtime_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_action")
     notification_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_notification_action")
     thread_input_action_module = importlib.import_module("backend.threads.chat_adapters.runtime_thread_input_action")
 
+    assert not hasattr(runtime_action_module, "dispatch_runtime_action_envelope")
     assert not hasattr(notification_action_module, "dispatch_runtime_notification_envelopes")
     assert not hasattr(thread_input_action_module, "dispatch_runtime_thread_input_envelopes")
 


### PR DESCRIPTION
## Summary

- make runtime action envelope dispatch an internal helper
- add a boundary guard so `runtime_action.py` does not publish that helper as public surface

## Verification

- red first: boundary test failed while `dispatch_runtime_action_envelope` was exported
- `uv run pytest tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py::test_runtime_action_adapters_do_not_export_envelope_dispatch_helpers tests/Unit/backend/web/services/test_runtime_action_dispatcher.py tests/Unit/integration_contracts/test_threads_router.py -q`
- `uv run ruff check backend/threads/chat_adapters/runtime_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pyright backend/threads/chat_adapters/runtime_action.py tests/Unit/backend/web/services/test_agent_runtime_gateway_protocol_boundary.py`
- `uv run pytest tests/Unit/backend tests/Unit/integration_contracts -q`
